### PR TITLE
feat: Create basic webterminal proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ A generic websocket proxy for [Web Terminal Operator](https://github.com/redhat-
 
 ## Why do we need yet another proxy?
 
-TBD
-
+When we want to utilize the Kubernetes `exec` endpoint to execute commands in the pod, we have to authorize using the `Authorization: Bearer` header. JavaScript [WebSocket API](https://websockets.spec.whatwg.org/#the-websocket-interface), which is supported by modern browsers, does not allow additional headers. We have to have a proxy that will accept input from the frontend, and after adding this header, it will send it to the `exec` endpoint. 
 ## Developer guide
 
 TBD

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/janus-idp/webterminal-proxy
+
+go 1.19
+
+require github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	utils "github.com/janus-idp/webterminal-proxy/utils"
+)
+
+const (
+	CONTAINER                       = "web-terminal-tooling"
+	HANDSHAKE_SUBPROTOCOL           = "terminal.k8s.io"
+	SERVER_ADDRESS_SUBPROTOCOL      = "base64url.console.link.k8s.io."
+	AUTHORIZATION_TOKEN_SUBPROTOCOL = "base64url.bearer.authorization.k8s.io."
+	WORKSPACE_ID_SUBPROTOCOL        = "base64url.workspace.id.k8s.io."
+	TERMINAL_ID_SUBPROTOCOL         = "base64url.terminal.id.k8s.io."
+	TERMINAL_SIZE_SUBPROTOCOL       = "base64url.terminal.size.k8s.io."
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	Subprotocols:    []string{HANDSHAKE_SUBPROTOCOL},
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}
+
+func setupCommandString(connectionData utils.ConnectionData) string {
+	commands := []string{"/bin/sh", "-i", "-c", fmt.Sprintf("stty cols %s rows %s; TERM=xterm bash", connectionData.TerminalSize[0], connectionData.TerminalSize[1])}
+	finalCommand := ""
+	for _, command := range commands {
+		finalCommand += "&command=" + url.QueryEscape(command)
+	}
+	finalCommand += "&stdout=1&stdin=1&stderr=1&tty=1"
+	return finalCommand
+}
+
+func setupPod(connectionData utils.ConnectionData) (string, error) {
+	username, err := utils.GetUserName(connectionData)
+	if err != nil {
+		return "", err
+	}
+	config := &utils.Config{
+		Container: CONTAINER,
+		Kubeconfig: utils.KubeConfig{
+			Username:  username,
+			Namespace: utils.NAMESPACE,
+		},
+	}
+	podID, err := utils.SetupUserPod(connectionData, config)
+	if err != nil {
+		return "", err
+	}
+	return podID, nil
+}
+
+func parseSubprotocols(r *http.Request) (utils.ConnectionData, error) {
+	var connectionData utils.ConnectionData
+	var err error
+	for _, subprotocol := range strings.Split(r.Header.Get("Sec-WebSocket-Protocol"), ", ") {
+		subprotocol = strings.TrimSpace(subprotocol)
+		switch {
+		case strings.HasPrefix(subprotocol, SERVER_ADDRESS_SUBPROTOCOL):
+			connectionData.Link, err = url.QueryUnescape(strings.TrimPrefix(subprotocol, SERVER_ADDRESS_SUBPROTOCOL))
+			if err != nil {
+				return connectionData, err
+			}
+		case strings.HasPrefix(subprotocol, AUTHORIZATION_TOKEN_SUBPROTOCOL):
+			connectionData.Token, err = url.QueryUnescape(strings.TrimPrefix(subprotocol, AUTHORIZATION_TOKEN_SUBPROTOCOL))
+			if err != nil {
+				return connectionData, err
+			}
+		case strings.HasPrefix(subprotocol, WORKSPACE_ID_SUBPROTOCOL):
+			connectionData.WorkspaceID, err = url.QueryUnescape(strings.TrimPrefix(subprotocol, WORKSPACE_ID_SUBPROTOCOL))
+			if err != nil {
+				return connectionData, err
+			}
+		case strings.HasPrefix(subprotocol, TERMINAL_ID_SUBPROTOCOL):
+			connectionData.TerminalID, err = url.QueryUnescape(strings.TrimPrefix(subprotocol, TERMINAL_ID_SUBPROTOCOL))
+			if err != nil {
+				return connectionData, err
+			}
+		case strings.HasPrefix(subprotocol, TERMINAL_SIZE_SUBPROTOCOL):
+			terminalSize, err := url.QueryUnescape(strings.TrimPrefix(subprotocol, TERMINAL_SIZE_SUBPROTOCOL))
+			if err != nil {
+				return connectionData, err
+			}
+			connectionData.TerminalSize = strings.Split(terminalSize, "x")
+		default:
+		}
+
+	}
+	return connectionData, nil
+
+}
+
+func connectWebsocketServer(connectionData utils.ConnectionData) *websocket.Conn {
+	dialer := websocket.DefaultDialer
+	dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	command := setupCommandString(connectionData)
+	c, response, err := dialer.Dial(fmt.Sprintf("wss://%s/api/v1/namespaces/%s/pods/%s/exec?&container=%s%s", connectionData.Link, utils.NAMESPACE, connectionData.PodID, CONTAINER, command), http.Header{"Authorization": []string{"Bearer " + connectionData.Token}})
+	if err != nil {
+		log.Fatal("Unable to connect a pod: ", err, " With response: ", response)
+		return nil
+	}
+	return c
+}
+
+func keepAlive(podConnection *websocket.Conn) {
+	buffer := bytes.NewBuffer([]byte{0})
+	buffer.WriteString("Keep alive")
+	for {
+		err := podConnection.WriteMessage(websocket.PingMessage, buffer.Bytes())
+		if err != nil {
+			log.Println("Unable to send keep alive message to pod: ", err)
+			return
+		}
+		time.Sleep(30 * time.Second)
+	}
+}
+
+func clientInput(clientConnection *websocket.Conn, podConnection *websocket.Conn, connectionData utils.ConnectionData) {
+	ticker := time.NewTicker(5 * time.Minute)
+	for {
+		messageType, message, err := clientConnection.ReadMessage()
+		if err != nil {
+			log.Println("Client read error: ", err)
+			return
+		}
+		buffer := bytes.NewBuffer([]byte{0})
+		buffer.WriteString(string(message))
+		err = podConnection.WriteMessage(messageType, buffer.Bytes())
+		if err != nil {
+			log.Println("Pod write error: ", err)
+			return
+		}
+		select {
+		case <-ticker.C:
+			err = utils.SendActivityTick(connectionData)
+			if err != nil {
+				log.Println("Unable to send activity tick: ", err)
+				return
+			}
+		default:
+		}
+	}
+}
+
+func terminalOutput(clientConnection *websocket.Conn, podConnection *websocket.Conn, connectionData utils.ConnectionData) {
+	ticker := time.NewTicker(1 * time.Minute)
+	for {
+		messageType, message, err := podConnection.ReadMessage()
+		if err != nil {
+			log.Println("Pod read: ", err, messageType, message)
+			return
+		}
+		err = clientConnection.WriteMessage(messageType, message)
+		if err != nil {
+			log.Println("Client write: ", err)
+			return
+		}
+		select {
+		case <-ticker.C:
+			err = utils.SendActivityTick(connectionData)
+			if err != nil {
+				log.Println("Unable to send activity tick: ", err)
+				return
+			}
+		default:
+		}
+	}
+}
+func handleWebsocket(w http.ResponseWriter, r *http.Request) {
+	h := http.Header{}
+	h.Set("Sec-WebSocket-Protocol", HANDSHAKE_SUBPROTOCOL)
+	connectionData, err := parseSubprotocols(r)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	defer utils.CleanAfterDisconnect(connectionData)
+	connectionData.PodID, err = setupPod(connectionData)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	clientConnection, err := upgrader.Upgrade(w, r, h)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	podConnection := connectWebsocketServer(connectionData)
+	go terminalOutput(clientConnection, podConnection, connectionData)
+	go keepAlive(podConnection)
+	clientInput(clientConnection, podConnection, connectionData)
+	log.Println("Connection closed")
+}
+
+func setupRoute() {
+	http.HandleFunc("/", handleWebsocket)
+}
+
+func main() {
+	setupRoute()
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/utils/requests.go
+++ b/utils/requests.go
@@ -1,0 +1,105 @@
+package utils
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+)
+
+var restClient = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+}
+
+const (
+	NAMESPACE                 = "openshift-terminal"
+	USER_ENDPOINT             = "apis/user.openshift.io/v1/users/~"
+	SERVICE_ENDPOINT          = "api/v1/namespaces/" + NAMESPACE + "/services"
+	SERVICE_EXEC_ENDPOINT     = "service:4444/proxy/exec/init"
+	SERVICE_ACTIVITY_ENDPOINT = "service:4444/proxy/activity/tick"
+)
+
+var DEVWORKSPACE_ENDPOINT = "apis/workspace.devfile.io/v1alpha2/namespaces/" + NAMESPACE + "/devworkspaces"
+
+func SetupUserPod(connectionData ConnectionData, config *Config) (string, error) {
+	payload, _ := json.Marshal(config)
+	request, err := http.NewRequest("POST", fmt.Sprintf("https://%s/%s/https:%s-%s", connectionData.Link, SERVICE_ENDPOINT, connectionData.WorkspaceID, SERVICE_EXEC_ENDPOINT), bytes.NewBuffer(payload))
+	if err != nil {
+		return "", err
+	}
+	request.Header = http.Header{
+		"Authorization":            {"Bearer " + connectionData.Token},
+		"Content-Type":             {"application/json"},
+		"X-Forwarded-Access-Token": {connectionData.Token},
+	}
+	response, err := restClient.Do(request)
+	if err != nil {
+		return "", err
+	}
+	body, _ := io.ReadAll(response.Body)
+	var workspaceRunning WorkspacePod
+	json.Unmarshal(body, &workspaceRunning)
+	pod := workspaceRunning.Pod
+	return pod, nil
+}
+
+func GetUserName(connectionData ConnectionData) (string, error) {
+	request, err := http.NewRequest("GET", fmt.Sprintf("https://%s/%s", connectionData.Link, USER_ENDPOINT), nil)
+	if err != nil {
+		return "", err
+	}
+	request.Header = http.Header{
+		"Authorization": {"Bearer " + connectionData.Token},
+		"Content-Type":  {"application/json"},
+	}
+	response, err := restClient.Do(request)
+	if err != nil {
+		return "", err
+	}
+	body, _ := io.ReadAll(response.Body)
+	var user User
+	json.Unmarshal(body, &user)
+	return user.Metadata.Name, nil
+}
+
+func CleanAfterDisconnect(connectionData ConnectionData) {
+	request, err := http.NewRequest("DELETE", fmt.Sprintf("https://%s/%s/%s", connectionData.Link, DEVWORKSPACE_ENDPOINT, connectionData.TerminalID), nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	request.Header = http.Header{
+		"Authorization": {"Bearer " + connectionData.Token},
+	}
+	response, err := restClient.Do(request)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	if response.StatusCode != 200 {
+		log.Println("Error while deleting workspace")
+	}
+}
+
+func SendActivityTick(connectionData ConnectionData) error {
+	request, err := http.NewRequest("POST", fmt.Sprintf("https://%s/%s/https:%s-%s", connectionData.Link, SERVICE_ENDPOINT, connectionData.WorkspaceID, SERVICE_ACTIVITY_ENDPOINT), nil)
+	if err != nil {
+		return err
+	}
+	log.Println("Sending activity tick")
+	request.Header = http.Header{
+		"Authorization":            {"Bearer " + connectionData.Token},
+		"Content-Type":             {"application/json"},
+		"X-Forwarded-Access-Token": {connectionData.Token},
+	}
+	_, err = restClient.Do(request)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/utils/types.go
+++ b/utils/types.go
@@ -1,0 +1,29 @@
+package utils
+
+type ConnectionData struct {
+	Link         string
+	Token        string
+	PodID        string
+	TerminalID   string
+	WorkspaceID  string
+	TerminalSize []string
+}
+
+type KubeConfig struct {
+	Username  string
+	Namespace string
+}
+type Config struct {
+	Container  string
+	Kubeconfig KubeConfig
+}
+
+type WorkspacePod struct {
+	Pod string `json:"pod"`
+}
+
+type User struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+}


### PR DESCRIPTION
This PR creates a basic proxy that establishes connection between webterminal plugin and `exec` endpoint of the pod. It also provides functionality such login of the user in the pod, which is blocked in the browser, and deletion of the workspace since client might end abruptly and he would leave a unused workspace in the cluster. 
Related to: https://github.com/operate-first/service-catalog/pull/206