### PR TITLE
feat: Add Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+COPY . .
+RUN go build -o .
+
+FROM registry.access.redhat.com/ubi9-micro:latest
+COPY --from=builder  /opt/app-root/src/webterminal-proxy /
+ENTRYPOINT ["/webterminal-proxy"]


### PR DESCRIPTION
As a step to prepare deployment of webterminal-proxy I setup a simple Containerfile.
I tried using following [Dockerfile](https://github.com/openshift/oauth-proxy/blob/master/Dockerfile) as a base, but the image used in this Dockerfile requires authorization which I don't think is ideal. 
Second I tried using ubi8/9 [images](https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690), but there seems to be an issue with these images, which is tracked [here](https://github.com/containers/podman/issues/17223) (I tried suggested fix in this issue and it did not work)
So I have decided (for now) to use docker golang image which seems to work just fine...

Part of: https://github.com/janus-idp/backstage-plugins/issues/81