### PR TITLE
feat: Add support for variable namespaces

### DIFF
--- a/utils/types.go
+++ b/utils/types.go
@@ -7,6 +7,7 @@ type ConnectionData struct {
 	TerminalID   string
 	WorkspaceID  string
 	TerminalSize []string
+	Namespace    string
 }
 
 type KubeConfig struct {


### PR DESCRIPTION
This PR introduces changes to enable usage of variable namespace it also refactors a subprotocols parsing to make it more easily expandable.
Part of: https://github.com/operate-first/service-catalog/issues/213
Related to: https://github.com/operate-first/service-catalog/pull/214