### PR TITLE
ci: Add PR workflow for linting, building and testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,35 @@
+name: pr
+
+on: pull_request
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # pin@v3.0
+        with:
+          go-version: "1.19"
+
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@c675eb70db3aa26b496bc4e64da320480338d41b # pin#v3
+        with:
+          version: v1.51.2
+
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # pin@v3.0
+        with:
+          go-version: "1.19"
+
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # pin@v3
+
+      - name: Build
+        run: go build -v
+
+      - name: Test
+        run: go test -v ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,15 @@
+run:
+  deadline: 5m
+
+# Use `golangci-lint help linters` for info about all available linters 
+# Install golangci here: https://golangci-lint.run/usage/install/
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - whitespace
+    - gci
+    - misspell
+  fast: false
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+---
+repos:
+  - repo: https://github.com/golangci/golangci-lint.git
+    rev: v1.51.2
+    hooks:
+      # See .golangci.yaml for config
+      - id: golangci-lint
+        
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ A generic websocket proxy for [Web Terminal Operator](https://github.com/redhat-
 
 ## Why do we need yet another proxy?
 
-When we want to utilize the Kubernetes `exec` endpoint to execute commands in the pod, we have to authorize using the `Authorization: Bearer` header. JavaScript [WebSocket API](https://websockets.spec.whatwg.org/#the-websocket-interface), which is supported by modern browsers, does not allow additional headers. We have to have a proxy that will accept input from the frontend, and after adding this header, it will send it to the `exec` endpoint. 
+When we want to utilize the Kubernetes `exec` endpoint to execute commands in the pod, we have to authorize using the `Authorization: Bearer` header. JavaScript [WebSocket API](https://websockets.spec.whatwg.org/#the-websocket-interface), which is supported by modern browsers, does not allow additional headers. We have to have a proxy that will accept input from the frontend, and after adding this header, it will send it to the `exec` endpoint.
+
+## Precommit hooks
+
+This repository uses [pre-commit](https://pre-commit.com/). You can install it [here](https://pre-commit.com/#install). To run pre-commit automatically for commits run:
+
+```sh
+pre-commit install
+```
+
 ## Developer guide
 
 TBD

--- a/proxy.go
+++ b/proxy.go
@@ -94,10 +94,8 @@ func parseSubprotocols(r *http.Request) (utils.ConnectionData, error) {
 				break
 			}
 		}
-
 	}
 	return connectionData, nil
-
 }
 
 func connectWebsocketServer(connectionData utils.ConnectionData) *websocket.Conn {


### PR DESCRIPTION
Part of #4 

Add a PR workflow that contains:
- Build and test job
- Linting using [`golangci`](https://golangci-lint.run/)

The lint runner is configured to use some basic linters like `gofmt`,  more can configured in `.golangci.yaml`. Also add `pre-commit` configuration that also uses `golangci`.