### PR TITLE
feat: Add REST proxy to webterminal proxy

### DIFF
--- a/utils/requests.go
+++ b/utils/requests.go
@@ -102,3 +102,42 @@ func SendActivityTick(connectionData ConnectionData) error {
 	}
 	return nil
 }
+
+func SendPostRequest(url string, payload []byte, authorizationToken string) ([]byte, int, error) {
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	request.Header = http.Header{
+		"Authorization": {authorizationToken},
+		"Content-Type":  {"application/json"},
+	}
+	response, err := restClient.Do(request)
+	if err != nil {
+		return nil, response.StatusCode, err
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return body, response.StatusCode, nil
+}
+
+func SendGetRequest(url string, authorizationToken string) ([]byte, int, error) {
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	request.Header = http.Header{
+		"Authorization": {authorizationToken},
+	}
+	response, err := restClient.Do(request)
+	if err != nil {
+		return nil, response.StatusCode, err
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	return body, response.StatusCode, nil
+}


### PR DESCRIPTION
This PR adds new REST endpoint which parses POST and GET requests. It acts as a proxy between frontend and kubernetes cluster. It pases request to the url that is specified in the url of the request and once it received response it passes it back to the sender.