### PR TITLE
fix: Fix issue with proxy not using valid path

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -252,8 +252,8 @@ func handleWebsocket(w http.ResponseWriter, r *http.Request) {
 }
 
 func setupRoute() {
-	http.HandleFunc("/rest", handleRestRequest)
-	http.HandleFunc("/", handleWebsocket)
+	http.HandleFunc("/webterminal/rest", handleRestRequest)
+	http.HandleFunc("/webterminal", handleWebsocket)
 }
 
 func main() {


### PR DESCRIPTION
This PR fixes an issue with pathing where deployed route for the applications starts with `/webterminal` but in the proxy it was expecting just `/` openshift route does not translate these paths therefore it was failing to properly resolve