### PR TITLE
Fix docker build issue (error obtaining VCS status)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/.*
+/webterminal-proxy

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/webterminal-proxy


### PR DESCRIPTION
I want to build this webterminal-proxy to test the Janus [webtermina-plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/web-terminal) but couldn't build it on OpenShift nor my machine when running:

I got this error when running `go build -o .` or `docker build .`.

And, I got the same issue when building on an OpenShift cluster:

```
 => ERROR [builder 3/3] RUN go build -o .                                                                                                              0.4s
------                                                                                                                                                      
 > [builder 3/3] RUN go build -o .:                                                                                                                         
0.202 go: downloading github.com/gorilla/websocket v1.5.0                                                                                                   
0.402 error obtaining VCS status: exit status 128
0.402 	Use -buildvcs=false to disable VCS stamping.
------
Dockerfile:3
--------------------
   1 |     FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
   2 |     COPY . .
   3 | >>> RUN go build -o .
   4 |     
   5 |     FROM registry.access.redhat.com/ubi9-micro:latest
--------------------
ERROR: failed to solve: process "/bin/sh -c go build -o ." did not complete successfully: exit code: 1
```

My go version is: go1.21.5 linux/amd64

The docker image uses currently: go version go1.20.10 linux/amd64

I added `-buildvcs=false` to solve that bug. See https://github.com/golang/go/issues/49004

To be honest, I'm unsure why this is now required. Wdyt?